### PR TITLE
Fix Ghoul Immortality Tech appearing on every trade goods list

### DIFF
--- a/react-app/src/components/TagGenerator.tsx
+++ b/react-app/src/components/TagGenerator.tsx
@@ -73,6 +73,11 @@ export function TagGenerator({ tags, standardCommodities, onApply }: Props) {
 
     const goods = standardCommodities.filter((c) => {
       const types = c.types.split(", ");
+      // Maltech items should only appear when Maltech is explicitly relevant,
+      // not just because they share another type (e.g. Medical) with common tags
+      if (types.includes("Maltech") && !relevantTypes.has("Maltech")) {
+        return false;
+      }
       return types.some((t) => relevantTypes.has(t));
     });
 


### PR DESCRIPTION
Maltech commodities were included in trade goods whenever any of their types matched a relevant type. Since Ghoul Immortality Tech has both Medical and Maltech types, and Medical is demanded by ~25 tags, it appeared on nearly every generated list. Now Maltech items are excluded unless Maltech is explicitly a relevant type from the planet's tags.

https://claude.ai/code/session_01Mh6YEJpxbRf82zJAhYh7x3